### PR TITLE
Reduce upload all button flickering

### DIFF
--- a/app/src/main/java/dev/kostromdan/mods/crash_assistant/app/gui/ControlPanel.java
+++ b/app/src/main/java/dev/kostromdan/mods/crash_assistant/app/gui/ControlPanel.java
@@ -107,7 +107,7 @@ public class ControlPanel {
                 SwingUtilities.invokeLater(() -> {
                     double lestTime = (CrashAssistantApp.terminatedProcessesLocationEndTime - Instant.now().toEpochMilli() + 100) / 1000.0D;
                     uploadAllButton.setText(LanguageProvider.get("gui.upload_all_button_delayed")
-                            .replaceAll("\\$SECONDS\\$", String.format("%f", lestTime)));
+                            .replaceAll("\\$SECONDS\\$", String.format("%.0f", lestTime)));
 
                     if (Instant.now().toEpochMilli() >= CrashAssistantApp.terminatedProcessesLocationEndTime + 100) {
                         uploadAllButton.setText(LanguageProvider.get("gui.upload_all_button"));

--- a/app/src/main/java/dev/kostromdan/mods/crash_assistant/app/gui/ControlPanel.java
+++ b/app/src/main/java/dev/kostromdan/mods/crash_assistant/app/gui/ControlPanel.java
@@ -107,7 +107,7 @@ public class ControlPanel {
                 SwingUtilities.invokeLater(() -> {
                     double lestTime = (CrashAssistantApp.terminatedProcessesLocationEndTime - Instant.now().toEpochMilli() + 100) / 1000.0D;
                     uploadAllButton.setText(LanguageProvider.get("gui.upload_all_button_delayed")
-                            .replaceAll("\\$SECONDS\\$", String.format("%.3f", lestTime)));
+                            .replaceAll("\\$SECONDS\\$", String.format("%f", lestTime)));
 
                     if (Instant.now().toEpochMilli() >= CrashAssistantApp.terminatedProcessesLocationEndTime + 100) {
                         uploadAllButton.setText(LanguageProvider.get("gui.upload_all_button"));


### PR DESCRIPTION
I don't really see a reason why upload all has more digits on the timer compared to other buttons. I would argue that it distracts from the main messages of the crash popup itself, hence proposing to remove the digits.

Of course, you may also reject the proposal and add a config option instead.